### PR TITLE
Draft: #645 added run_at_timezone field to chain and add_job #646

### DIFF
--- a/internal/pgengine/access.go
+++ b/internal/pgengine/access.go
@@ -83,7 +83,7 @@ func (pge *PgEngine) SelectRebootChains(ctx context.Context, dest *[]Chain) erro
 
 // SelectChains returns a list of chains should be executed at the current moment
 func (pge *PgEngine) SelectChains(ctx context.Context, dest *[]Chain) error {
-	const sqlSelectChains = sqlSelectLiveChains + ` AND NOT COALESCE(starts_with(run_at, '@'), FALSE) AND timetable.is_cron_in_time(run_at, now() AT TIME ZONE run_at_time_zone)`
+	const sqlSelectChains = sqlSelectLiveChains + ` AND NOT COALESCE(starts_with(run_at, '@'), FALSE) AND timetable.is_cron_in_time(run_at, now() AT TIME ZONE run_at_timezone)`
 	rows, err := pge.ConfigDb.Query(ctx, sqlSelectChains, pge.ClientName)
 	if err != nil {
 		return err

--- a/internal/pgengine/access.go
+++ b/internal/pgengine/access.go
@@ -83,7 +83,7 @@ func (pge *PgEngine) SelectRebootChains(ctx context.Context, dest *[]Chain) erro
 
 // SelectChains returns a list of chains should be executed at the current moment
 func (pge *PgEngine) SelectChains(ctx context.Context, dest *[]Chain) error {
-	const sqlSelectChains = sqlSelectLiveChains + ` AND NOT COALESCE(starts_with(run_at, '@'), FALSE) AND timetable.is_cron_in_time(run_at, now())`
+	const sqlSelectChains = sqlSelectLiveChains + ` AND NOT COALESCE(starts_with(run_at, '@'), FALSE) AND timetable.is_cron_in_time(run_at, now() AT TIME ZONE run_at_time_zone)`
 	rows, err := pge.ConfigDb.Query(ctx, sqlSelectChains, pge.ClientName)
 	if err != nil {
 		return err

--- a/internal/pgengine/migration.go
+++ b/internal/pgengine/migration.go
@@ -142,7 +142,7 @@ var Migrations func() migrator.Option = func() migrator.Option {
 			},
 		},
 		&migrator.Migration{
-			Name: "00645 Change is_cron_in_time ts param to timestamp without time zone",
+			Name: "00645 Add option to specify time zone per chain",
 			Func: func(ctx context.Context, tx pgx.Tx) error {
 				return ExecuteMigrationScript(ctx, tx, "00645.sql")
 			},

--- a/internal/pgengine/migration.go
+++ b/internal/pgengine/migration.go
@@ -141,6 +141,12 @@ var Migrations func() migrator.Option = func() migrator.Option {
 				return ExecuteMigrationScript(ctx, tx, "00629.sql")
 			},
 		},
+		&migrator.Migration{
+			Name: "00645 Change is_cron_in_time ts param to timestamp without time zone",
+			Func: func(ctx context.Context, tx pgx.Tx) error {
+				return ExecuteMigrationScript(ctx, tx, "00645.sql")
+			},
+		},
 		// adding new migration here, update "timetable"."migration" in "sql/init.sql"
 		// and "dbapi" variable in main.go!
 

--- a/internal/pgengine/pgengine_test.go
+++ b/internal/pgengine/pgengine_test.go
@@ -80,7 +80,7 @@ func TestInitAndTestConfigDBConnection(t *testing.T) {
 		funcNames := []string{"_validate_json_schema_type(text, jsonb)",
 			"validate_json_schema(jsonb, jsonb, jsonb)",
 			"add_task(timetable.command_kind, TEXT, BIGINT, DOUBLE PRECISION)",
-			"add_job(TEXT, timetable.cron, TEXT, JSONB, timetable.command_kind, TEXT, INTEGER, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, TEXT)",
+			"add_job(TEXT, timetable.cron, TEXT, JSONB, timetable.command_kind, TEXT, INTEGER, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, TEXT, TEXT)",
 			"is_cron_in_time(timetable.cron, timestamptz)"}
 		for _, funcName := range funcNames {
 			err := pge.ConfigDb.QueryRow(ctx, fmt.Sprintf("SELECT COALESCE(to_regprocedure('timetable.%s'), 0) :: int", funcName)).Scan(&oid)

--- a/internal/pgengine/sql/cron.sql
+++ b/internal/pgengine/sql/cron.sql
@@ -144,7 +144,7 @@ COMMENT ON DOMAIN timetable.cron IS 'Extended CRON-style notation with support o
 -- is_cron_in_time returns TRUE if timestamp is listed in cron expression
 CREATE OR REPLACE FUNCTION timetable.is_cron_in_time(
     run_at timetable.cron, 
-    ts timestamptz
+    ts timestamp
 ) RETURNS BOOLEAN AS $$
     SELECT
     CASE WHEN run_at IS NULL THEN

--- a/internal/pgengine/sql/ddl.sql
+++ b/internal/pgengine/sql/ddl.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION timetable.is_pg_timetable_name(TEXT) RETURNS BOOLEAN AS
+CREATE FUNCTION timetable.is_valid_timezone(TEXT) RETURNS BOOLEAN AS
 $$
     SELECT $1 IN (SELECT name FROM pg_timezone_names());
 $$ LANGUAGE sql;
@@ -15,7 +15,7 @@ CREATE TABLE timetable.chain (
     client_name         TEXT,
     on_error            TEXT,
     run_at_timezone     TEXT        DEFAULT current_setting('timezone')
-        constraint valid_run_at_timezone check (timetable.is_pg_timetable_name(run_at_timezone))
+        constraint valid_run_at_timezone check (timetable.is_valid_timezone(run_at_timezone))
 );
 
 COMMENT ON TABLE timetable.chain IS

--- a/internal/pgengine/sql/ddl.sql
+++ b/internal/pgengine/sql/ddl.sql
@@ -9,7 +9,7 @@ CREATE TABLE timetable.chain (
     exclusive_execution BOOLEAN     DEFAULT FALSE,
     client_name         TEXT,
     on_error            TEXT,
-    run_at_time_zone    TEXT        NOT NULL DEFAULT current_setting('TIMEZONE')
+    run_at_timezone    TEXT        NOT NULL DEFAULT current_setting('timezone')
 );
 
 COMMENT ON TABLE timetable.chain IS

--- a/internal/pgengine/sql/ddl.sql
+++ b/internal/pgengine/sql/ddl.sql
@@ -8,7 +8,8 @@ CREATE TABLE timetable.chain (
     self_destruct       BOOLEAN     DEFAULT FALSE,
     exclusive_execution BOOLEAN     DEFAULT FALSE,
     client_name         TEXT,
-    on_error            TEXT
+    on_error            TEXT,
+    run_at_time_zone    TEXT        NOT NULL DEFAULT current_setting('TIMEZONE')
 );
 
 COMMENT ON TABLE timetable.chain IS

--- a/internal/pgengine/sql/ddl.sql
+++ b/internal/pgengine/sql/ddl.sql
@@ -1,3 +1,8 @@
+CREATE FUNCTION timetable.is_pg_timetable_name(TEXT) RETURNS BOOLEAN AS
+$$
+    SELECT $1 IN (SELECT name FROM pg_timezone_names());
+$$ LANGUAGE sql;
+
 CREATE TABLE timetable.chain (
     chain_id            BIGSERIAL   PRIMARY KEY,
     chain_name          TEXT        NOT NULL UNIQUE,
@@ -9,7 +14,8 @@ CREATE TABLE timetable.chain (
     exclusive_execution BOOLEAN     DEFAULT FALSE,
     client_name         TEXT,
     on_error            TEXT,
-    run_at_timezone    TEXT        NOT NULL DEFAULT current_setting('timezone')
+    run_at_timezone     TEXT        DEFAULT current_setting('timezone')
+        constraint valid_run_at_timezone check (timetable.is_pg_timetable_name(run_at_timezone))
 );
 
 COMMENT ON TABLE timetable.chain IS

--- a/internal/pgengine/sql/init.sql
+++ b/internal/pgengine/sql/init.sql
@@ -27,4 +27,4 @@ VALUES
     (11, '00573 Add ability to start a chain with delay'),
     (12, '00575 Add on_error handling'),
     (13, '00629 Add ignore_error column to timetable.execution_log'),
-    (14, '00645 Change is_cron_in_time ts param to timestamp without time zone');
+    (14, '00645 Add option to specify time zone per chain');

--- a/internal/pgengine/sql/init.sql
+++ b/internal/pgengine/sql/init.sql
@@ -26,4 +26,5 @@ VALUES
     (10, '00560 Alter txid column to bigint'),
     (11, '00573 Add ability to start a chain with delay'),
     (12, '00575 Add on_error handling'),
-    (13, '00629 Add ignore_error column to timetable.execution_log');
+    (13, '00629 Add ignore_error column to timetable.execution_log'),
+    (14, '00645 Change is_cron_in_time ts param to timestamp without time zone');

--- a/internal/pgengine/sql/job_functions.sql
+++ b/internal/pgengine/sql/job_functions.sql
@@ -26,7 +26,7 @@ CREATE OR REPLACE FUNCTION timetable.add_job(
     job_ignore_errors   BOOLEAN DEFAULT TRUE,
     job_exclusive       BOOLEAN DEFAULT FALSE,
     job_on_error        TEXT DEFAULT NULL,
-    job_timezone       TEXT DEFAULT current_setting('timezone')
+    job_timezone        TEXT DEFAULT current_setting('timezone')
 ) RETURNS BIGINT AS $$
     WITH 
         cte_chain (v_chain_id) AS (

--- a/internal/pgengine/sql/job_functions.sql
+++ b/internal/pgengine/sql/job_functions.sql
@@ -26,12 +26,12 @@ CREATE OR REPLACE FUNCTION timetable.add_job(
     job_ignore_errors   BOOLEAN DEFAULT TRUE,
     job_exclusive       BOOLEAN DEFAULT FALSE,
     job_on_error        TEXT DEFAULT NULL,
-    job_time_zone       TEXT DEFAULT current_setting('TIMEZONE')
+    job_timezone       TEXT DEFAULT current_setting('timezone')
 ) RETURNS BIGINT AS $$
     WITH 
         cte_chain (v_chain_id) AS (
-            INSERT INTO timetable.chain (chain_name, run_at, max_instances, live, self_destruct, client_name, exclusive_execution, on_error, run_at_time_zone) 
-            VALUES (job_name, job_schedule,job_max_instances, job_live, job_self_destruct, job_client_name, job_exclusive, job_on_error, job_time_zone)
+            INSERT INTO timetable.chain (chain_name, run_at, max_instances, live, self_destruct, client_name, exclusive_execution, on_error, run_at_timezone) 
+            VALUES (job_name, job_schedule,job_max_instances, job_live, job_self_destruct, job_client_name, job_exclusive, job_on_error, job_timezone)
             RETURNING chain_id
         ),
         cte_task(v_task_id) AS (

--- a/internal/pgengine/sql/job_functions.sql
+++ b/internal/pgengine/sql/job_functions.sql
@@ -25,12 +25,13 @@ CREATE OR REPLACE FUNCTION timetable.add_job(
     job_self_destruct   BOOLEAN DEFAULT FALSE,
     job_ignore_errors   BOOLEAN DEFAULT TRUE,
     job_exclusive       BOOLEAN DEFAULT FALSE,
-    job_on_error        TEXT DEFAULT NULL
+    job_on_error        TEXT DEFAULT NULL,
+    job_time_zone       TEXT DEFAULT current_setting('TIMEZONE')
 ) RETURNS BIGINT AS $$
     WITH 
         cte_chain (v_chain_id) AS (
-            INSERT INTO timetable.chain (chain_name, run_at, max_instances, live, self_destruct, client_name, exclusive_execution, on_error) 
-            VALUES (job_name, job_schedule,job_max_instances, job_live, job_self_destruct, job_client_name, job_exclusive, job_on_error)
+            INSERT INTO timetable.chain (chain_name, run_at, max_instances, live, self_destruct, client_name, exclusive_execution, on_error, run_at_time_zone) 
+            VALUES (job_name, job_schedule,job_max_instances, job_live, job_self_destruct, job_client_name, job_exclusive, job_on_error, job_time_zone)
             RETURNING chain_id
         ),
         cte_task(v_task_id) AS (

--- a/internal/pgengine/sql/migrations/00645.sql
+++ b/internal/pgengine/sql/migrations/00645.sql
@@ -19,7 +19,7 @@ $$ LANGUAGE SQL;
 DROP FUNCTION timetable.is_cron_in_time(timetable.cron, timestamp with time zone);
 
 ALTER TABLE timetable.chain
-    ADD COLUMN run_at_time_zone TEXT DEFAULT current_setting('TIMEZONE') NOT NULL USING current_setting('TIMEZONE');
+    ADD COLUMN run_at_time_zone TEXT DEFAULT current_setting('TIMEZONE') NOT NULL;
 
 CREATE OR REPLACE FUNCTION timetable.add_job(
     job_name            TEXT,

--- a/internal/pgengine/sql/migrations/00645.sql
+++ b/internal/pgengine/sql/migrations/00645.sql
@@ -1,3 +1,4 @@
+DROP FUNCTION IF EXISTS timetable.is_cron_in_time;
 CREATE OR REPLACE FUNCTION timetable.is_cron_in_time(
     run_at timetable.cron, 
     ts timestamp
@@ -16,11 +17,10 @@ CREATE OR REPLACE FUNCTION timetable.is_cron_in_time(
         timetable.cron_split_to_arrays(run_at) a
 $$ LANGUAGE SQL;
 
-DROP FUNCTION timetable.is_cron_in_time(timetable.cron, timestamp with time zone);
-
 ALTER TABLE timetable.chain
     ADD COLUMN run_at_time_zone TEXT DEFAULT current_setting('TIMEZONE') NOT NULL;
 
+DROP FUNCTION IF EXISTS timetable.add_job;
 CREATE OR REPLACE FUNCTION timetable.add_job(
     job_name            TEXT,
     job_schedule        timetable.cron,
@@ -34,7 +34,7 @@ CREATE OR REPLACE FUNCTION timetable.add_job(
     job_ignore_errors   BOOLEAN DEFAULT TRUE,
     job_exclusive       BOOLEAN DEFAULT FALSE,
     job_on_error        TEXT DEFAULT NULL,
-    job_time_zone       TEXT DEFAULT current_setting('TIMEZONE')
+    job_time_zone       TEXT DEFAULT current_setting('timezone')
 ) RETURNS BIGINT AS $$
     WITH 
         cte_chain (v_chain_id) AS (
@@ -54,5 +54,3 @@ CREATE OR REPLACE FUNCTION timetable.add_job(
         )
         SELECT v_chain_id FROM cte_chain
 $$ LANGUAGE SQL;
-
-DROP FUNCTION timetable.add_job(TEXT, timetable.cron, TEXT, JSONB, timetable.command_kind, TEXT, INTEGER, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, TEXT);

--- a/internal/pgengine/sql/migrations/00645.sql
+++ b/internal/pgengine/sql/migrations/00645.sql
@@ -18,7 +18,7 @@ CREATE OR REPLACE FUNCTION timetable.is_cron_in_time(
 $$ LANGUAGE SQL;
 
 ALTER TABLE timetable.chain
-    ADD COLUMN run_at_time_zone TEXT DEFAULT current_setting('TIMEZONE') NOT NULL;
+    ADD COLUMN run_at_timezone TEXT DEFAULT current_setting('timezone') NOT NULL;
 
 DROP FUNCTION IF EXISTS timetable.add_job;
 CREATE OR REPLACE FUNCTION timetable.add_job(
@@ -34,12 +34,12 @@ CREATE OR REPLACE FUNCTION timetable.add_job(
     job_ignore_errors   BOOLEAN DEFAULT TRUE,
     job_exclusive       BOOLEAN DEFAULT FALSE,
     job_on_error        TEXT DEFAULT NULL,
-    job_time_zone       TEXT DEFAULT current_setting('timezone')
+    job_timezone       TEXT DEFAULT current_setting('timezone')
 ) RETURNS BIGINT AS $$
     WITH 
         cte_chain (v_chain_id) AS (
-            INSERT INTO timetable.chain (chain_name, run_at, max_instances, live, self_destruct, client_name, exclusive_execution, on_error, run_at_time_zone) 
-            VALUES (job_name, job_schedule,job_max_instances, job_live, job_self_destruct, job_client_name, job_exclusive, job_on_error, job_time_zone)
+            INSERT INTO timetable.chain (chain_name, run_at, max_instances, live, self_destruct, client_name, exclusive_execution, on_error, run_at_timezone) 
+            VALUES (job_name, job_schedule,job_max_instances, job_live, job_self_destruct, job_client_name, job_exclusive, job_on_error, job_timezone)
             RETURNING chain_id
         ),
         cte_task(v_task_id) AS (

--- a/internal/pgengine/sql/migrations/00645.sql
+++ b/internal/pgengine/sql/migrations/00645.sql
@@ -1,0 +1,58 @@
+CREATE OR REPLACE FUNCTION timetable.is_cron_in_time(
+    run_at timetable.cron, 
+    ts timestamp
+) RETURNS BOOLEAN AS $$
+    SELECT
+    CASE WHEN run_at IS NULL THEN
+        TRUE
+    ELSE
+        date_part('month', ts) = ANY(a.months)
+        AND (date_part('dow', ts) = ANY(a.dow) OR date_part('isodow', ts) = ANY(a.dow))
+        AND date_part('day', ts) = ANY(a.days)
+        AND date_part('hour', ts) = ANY(a.hours)
+        AND date_part('minute', ts) = ANY(a.mins)
+    END
+    FROM
+        timetable.cron_split_to_arrays(run_at) a
+$$ LANGUAGE SQL;
+
+DROP FUNCTION timetable.is_cron_in_time(timetable.cron, timestamp with time zone);
+
+ALTER TABLE timetable.chain
+    ADD COLUMN run_at_time_zone TEXT DEFAULT current_setting('TIMEZONE') NOT NULL USING current_setting('TIMEZONE');
+
+CREATE OR REPLACE FUNCTION timetable.add_job(
+    job_name            TEXT,
+    job_schedule        timetable.cron,
+    job_command         TEXT,
+    job_parameters      JSONB DEFAULT NULL,
+    job_kind            timetable.command_kind DEFAULT 'SQL'::timetable.command_kind,
+    job_client_name     TEXT DEFAULT NULL,
+    job_max_instances   INTEGER DEFAULT NULL,
+    job_live            BOOLEAN DEFAULT TRUE,
+    job_self_destruct   BOOLEAN DEFAULT FALSE,
+    job_ignore_errors   BOOLEAN DEFAULT TRUE,
+    job_exclusive       BOOLEAN DEFAULT FALSE,
+    job_on_error        TEXT DEFAULT NULL,
+    job_time_zone       TEXT DEFAULT current_setting('TIMEZONE')
+) RETURNS BIGINT AS $$
+    WITH 
+        cte_chain (v_chain_id) AS (
+            INSERT INTO timetable.chain (chain_name, run_at, max_instances, live, self_destruct, client_name, exclusive_execution, on_error, run_at_time_zone) 
+            VALUES (job_name, job_schedule,job_max_instances, job_live, job_self_destruct, job_client_name, job_exclusive, job_on_error, job_time_zone)
+            RETURNING chain_id
+        ),
+        cte_task(v_task_id) AS (
+            INSERT INTO timetable.task (chain_id, task_order, kind, command, ignore_error, autonomous)
+            SELECT v_chain_id, 10, job_kind, job_command, job_ignore_errors, TRUE
+            FROM cte_chain
+            RETURNING task_id
+        ),
+        cte_param AS (
+            INSERT INTO timetable.parameter (task_id, order_id, value)
+            SELECT v_task_id, 1, job_parameters FROM cte_task, cte_chain
+        )
+        SELECT v_chain_id FROM cte_chain
+$$ LANGUAGE SQL;
+
+DROP FUNCTION timetable.add_job(TEXT, timetable.cron, TEXT, JSONB, timetable.command_kind, TEXT, INTEGER, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, TEXT);

--- a/internal/pgengine/sql/migrations/00645.sql
+++ b/internal/pgengine/sql/migrations/00645.sql
@@ -17,15 +17,15 @@ CREATE OR REPLACE FUNCTION timetable.is_cron_in_time(
         timetable.cron_split_to_arrays(run_at) a
 $$ LANGUAGE SQL;
 
-DROP FUNCTION IF EXISTS timetable.is_pg_timetable_name;
-CREATE FUNCTION timetable.is_pg_timetable_name(TEXT) RETURNS BOOLEAN AS
+DROP FUNCTION IF EXISTS timetable.is_valid_timezone;
+CREATE FUNCTION timetable.is_valid_timezone(TEXT) RETURNS BOOLEAN AS
 $$
     SELECT $1 IN (SELECT name FROM pg_timezone_names());
 $$ LANGUAGE sql;
 
 ALTER TABLE timetable.chain
     ADD COLUMN run_at_timezone TEXT DEFAULT current_setting('timezone') NOT NULL,
-    ADD CONSTRAINT valid_run_at_timezone CHECK (timetable.is_pg_timetable_name(run_at_timezone));
+    ADD CONSTRAINT valid_run_at_timezone CHECK (timetable.is_valid_timezone(run_at_timezone));
 
 DROP FUNCTION IF EXISTS timetable.add_job;
 CREATE OR REPLACE FUNCTION timetable.add_job(

--- a/internal/pgengine/sql/migrations/00645.sql
+++ b/internal/pgengine/sql/migrations/00645.sql
@@ -34,7 +34,7 @@ CREATE OR REPLACE FUNCTION timetable.add_job(
     job_ignore_errors   BOOLEAN DEFAULT TRUE,
     job_exclusive       BOOLEAN DEFAULT FALSE,
     job_on_error        TEXT DEFAULT NULL,
-    job_timezone       TEXT DEFAULT current_setting('timezone')
+    job_timezone        TEXT DEFAULT current_setting('timezone')
 ) RETURNS BIGINT AS $$
     WITH 
         cte_chain (v_chain_id) AS (

--- a/internal/pgengine/sql/migrations/00645.sql
+++ b/internal/pgengine/sql/migrations/00645.sql
@@ -17,8 +17,15 @@ CREATE OR REPLACE FUNCTION timetable.is_cron_in_time(
         timetable.cron_split_to_arrays(run_at) a
 $$ LANGUAGE SQL;
 
+DROP FUNCTION IF EXISTS timetable.is_pg_timetable_name;
+CREATE FUNCTION timetable.is_pg_timetable_name(TEXT) RETURNS BOOLEAN AS
+$$
+    SELECT $1 IN (SELECT name FROM pg_timezone_names());
+$$ LANGUAGE sql;
+
 ALTER TABLE timetable.chain
-    ADD COLUMN run_at_timezone TEXT DEFAULT current_setting('timezone') NOT NULL;
+    ADD COLUMN run_at_timezone TEXT DEFAULT current_setting('timezone') NOT NULL,
+    ADD CONSTRAINT valid_run_at_timezone CHECK (timetable.is_pg_timetable_name(run_at_timezone));
 
 DROP FUNCTION IF EXISTS timetable.add_job;
 CREATE OR REPLACE FUNCTION timetable.add_job(

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -50,7 +50,7 @@ func TestRun(t *testing.T) {
 	assert.NoError(t, err, "Creating remote tasks failed")
 	err = pge.ExecuteCustomScripts(context.Background(), "../../samples/Basic.sql")
 	assert.NoError(t, err, "Creating sql tasks failed")
-	err = pge.ExecuteCustomScripts(context.Background(), "../../samples/TimeZone.sql")
+	err = pge.ExecuteCustomScripts(context.Background(), "../../samples/Timezone.sql")
 	assert.NoError(t, err, "Creating sql tasks failed")
 	err = pge.ExecuteCustomScripts(context.Background(), "../../samples/NoOp.sql")
 	assert.NoError(t, err, "Creating built-in tasks failed")

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -50,6 +50,8 @@ func TestRun(t *testing.T) {
 	assert.NoError(t, err, "Creating remote tasks failed")
 	err = pge.ExecuteCustomScripts(context.Background(), "../../samples/Basic.sql")
 	assert.NoError(t, err, "Creating sql tasks failed")
+	err = pge.ExecuteCustomScripts(context.Background(), "../../samples/TimeZone.sql")
+	assert.NoError(t, err, "Creating sql tasks failed")
 	err = pge.ExecuteCustomScripts(context.Background(), "../../samples/NoOp.sql")
 	assert.NoError(t, err, "Creating built-in tasks failed")
 	err = pge.ExecuteCustomScripts(context.Background(), "../../samples/Shell.sql")

--- a/samples/TimeZone.sql
+++ b/samples/TimeZone.sql
@@ -1,0 +1,13 @@
+SELECT timetable.add_job(
+    job_name            => 'test time zone',
+    job_schedule        => '* * * * *',
+    job_command         => 'SELECT pg_notify($1, $2)',
+    job_parameters      => '[ "TT_CHANNEL", "Ahoj from SQL base task" ]' :: jsonb,
+    job_kind            => 'SQL'::timetable.command_kind,
+    job_client_name     => NULL,
+    job_max_instances   => 1,
+    job_live            => TRUE,
+    job_self_destruct   => FALSE,
+    job_ignore_errors   => TRUE,
+    job_time_zone       => 'Europe/Berlin'
+) as chain_id;

--- a/samples/Timezone.sql
+++ b/samples/Timezone.sql
@@ -1,5 +1,5 @@
 SELECT timetable.add_job(
-    job_name            => 'test time zone',
+    job_name            => 'timezone can be set per job',
     job_schedule        => '* * * * *',
     job_command         => 'SELECT pg_notify($1, $2)',
     job_parameters      => '[ "TT_CHANNEL", "Ahoj from SQL base task" ]' :: jsonb,
@@ -9,5 +9,5 @@ SELECT timetable.add_job(
     job_live            => TRUE,
     job_self_destruct   => FALSE,
     job_ignore_errors   => TRUE,
-    job_time_zone       => 'Europe/Berlin'
+    job_timezone       => 'Europe/Berlin'
 ) as chain_id;


### PR DESCRIPTION
Continuing on from https://github.com/cybertec-postgresql/pg_timetable/pull/646 in my own fork.

Added new `run_at_timezone` field to the `chain` table to allow for optional separate time zone per chain. The default of `current_setting('timezone`)` will make this change backwards compatible.

Todo:
- [x]  add unit tests. ~~I haven't figured out how to run the unit tests locally yet.~~ Use the following to start postgres in docker before letting vscode run the unit tests in the `_test.go` files.

```sh
#!/usr/bin/env bash
set -euo pipefail # Exit with nonzero exit code if anything fails
set -x # Display commands and their arguments as they are executed.

docker rm -f postgres-pg-timetable-test || true
docker run --rm --name postgres-pg-timetable-test \
-p 5432:5432 \
-e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=mysecretpassword \
--add-host host.docker.internal:host-gateway \
--net host \
-d postgres:16.2

timeout 90s /usr/bin/env bash -c "until docker exec postgres-pg-timetable-test pg_isready ; do sleep 5 ; done" # wait for db to be ready
docker exec postgres-pg-timetable-test psql -U postgres -c "CREATE USER scheduler PASSWORD 'somestrong';"
docker exec postgres-pg-timetable-test psql -U postgres -c "CREATE DATABASE timetable OWNER scheduler;"
docker exec postgres-pg-timetable-test psql -U postgres -c "SELECT version();"
docker logs -f postgres-pg-timetable-test
```

- [x] test migrations.
- [ ] add docs